### PR TITLE
Gemfile の追加

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'net-irc'
+gem 'wxruby-ruby19', '2.0.0'
+gem 'ocra'


### PR DESCRIPTION
最近のRubyの開発には bundler と呼ばれるライブラリ管理アプリを使って、依存関係をプロジェクトにダウンロードして、グローバルのGemを汚さないようにしています。

このPRではLinux向けの設定を追加しました。Windowsでも通るとは思います。
使い方は `$ gem install bundler` を行い、その後 `BCDice/src` に移動して、 `$ bundle install --path vendor/bundle` です