### PR TITLE
実行ファイルをリポジトリから削除する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+/bcdice.exe
 /README.txt~
 /src/diceBot/tmp.txt
 /src/test/tmp.txt


### PR DESCRIPTION
どどんとふのSWFと同様にリポジトリからbcdice.exeを削除しました。これによりリポジトリの容量が大幅に小さくなり、`git pull` が速くなることが期待できます。

# 配布時に実行ファイルを含める方法

1. どどんとふと同様に、バージョンアップ時に
    ```bash
    git tag v2.02.67 # バージョンによって変える
    git push --tags
    ```
    でバージョンに対応したタグをアップロードします。
2. 実行ファイルを作成してフォルダをzipで固めます。
3. https://github.com/torgtaitai/BCDice/releases からタグのページに行き、zipファイルをアップロードします。

以上の手順で、そのバージョンの実行ファイルが含まれた配布用のファイルを掲載することができます。