### PR TITLE
log.rb: $isDebugを上書きしないようにする

### DIFF
--- a/src/log.rb
+++ b/src/log.rb
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-$isDebug = false
-
 # デバッグ文字列出力（末尾改行なし）
 def debugPrint(text)
   print($RUBY18_WIN ? text.tosjis : text)


### PR DESCRIPTION
configBcDice.rbでデバッグ出力を行うかを決める変数 `$isDebug` を設定できますが、log.rbが読み込まれた際に強制的に `false` に変えられてしまうため、これまでデバッグ出力ができない状態になっていました。log.rbから `$isDebug` の設定を消すことで、BCDice単体でデバッグ出力を見ることができるようにしました。