### PR TITLE
CgiDiceBot: $LOAD_PATHの追加し忘れを修正する

### DIFF
--- a/src/cgiDiceBot.rb
+++ b/src/cgiDiceBot.rb
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
 
+bcDiceRoot = File.expand_path(File.dirname(__FILE__))
+unless $LOAD_PATH.include?(bcDiceRoot)
+  $LOAD_PATH.unshift(bcDiceRoot)
+end
+
 require 'bcdiceCore.rb'
 
 class CgiDiceBot


### PR DESCRIPTION
BCDice単体の場合、Ruby 1.9以降でcgiDiceBot.rbが起動できない問題を修正しました。原因は$LOAD_PATHへのルートディレクトリの追加忘れでした。どどんとふで使う場合、どどんとふ側で$LOAD_PATHを設定しているため大丈夫だったようです。