### PR TITLE
DiceBotLoaderList: DarkSoulsを追加する

### DIFF
--- a/src/diceBot/DiceBotLoaderList.rb
+++ b/src/diceBot/DiceBotLoaderList.rb
@@ -141,6 +141,7 @@ class DiceBotLoaderList
     DiceBotLoader.new('Garako'),
     DiceBotLoader.new('ShoujoTenrankai'),
     DiceBotLoader.new('GardenOrder'),
+    DiceBotLoader.new('DarkSouls'),
     DiceBotLoader.new('None', :filenames => [], :class => :DiceBot)
   ]
 end

--- a/src/test/testDiceBotLoaders.rb
+++ b/src/test/testDiceBotLoaders.rb
@@ -449,6 +449,10 @@ class TestDiceBotLoaders < Test::Unit::TestCase
     assertDiceBot('GardenOrder', 'GardenOrder')
   end
 
+  def test_DarkSouls
+    assertDiceBot('DarkSouls', 'DarkSouls')
+  end
+
   private
 
   def assertDiceBot(gameType, pattern)


### PR DESCRIPTION
先日追加された「ダークソウルTRPG」がDiceBotLoaderListに追加されていなかったため、追加しました。これにより、setGameで大文字小文字の区別なしでダイスボットを読み込めるようになります。