### PR TITLE
ダイスボット収集処理をDiceBotLoaderに移す

### DIFF
--- a/src/createExe.rb
+++ b/src/createExe.rb
@@ -3,27 +3,15 @@
 
 require 'fileutils'
 
-$LOAD_PATH << File.dirname(__FILE__) # require_relative対策
+bcdiceRoot = File.expand_path(File.dirname(__FILE__))
+$LOAD_PATH.unshift(bcdiceRoot) unless $LOAD_PATH.include?(bcdiceRoot)
+
+require 'diceBot/DiceBotLoader'
 
 def updateConfig
-  ignoreBotNames = ['DiceBot', 'DiceBotLoader', 'DiceBotLoaderList', 'baseBot', '_Template', 'test']
-
-  require 'diceBot/DiceBot'
-  
-  botFiles = Dir.glob("diceBot/*.rb")
-  
-  botNames = botFiles.collect{|i| File.basename(i, ".rb").untaint}
-  botNames.delete_if{|i| ignoreBotNames.include?(i) }
-  
-  nameList = []
-  botNames.each do |botName|
-    require "diceBot/#{botName}"
-    diceBot = Module.const_get(botName).new
-    nameList << diceBot.gameType.gsub(/ /, '_')
-  end
-  
-  nameList.sort!
-  
+  nameList = DiceBotLoader.collectDiceBots.
+    map { |diceBot| diceBot.gameType.gsub(' ', '_') }.
+    sort
   writeToConfig(nameList)
 end
 

--- a/src/diceBot/DiceBotLoader.rb
+++ b/src/diceBot/DiceBotLoader.rb
@@ -44,7 +44,11 @@ class DiceBotLoader
     botFiles = Dir.glob("#{diceBotDir}/*.rb")
     botNames =
       botFiles.map { |botFile| File.basename(botFile, '.rb').untaint }
-    validBotNames = botNames - BOT_NAMES_TO_IGNORE
+    validBotNames =
+      # 特別な名前のものを除外する
+      (botNames - BOT_NAMES_TO_IGNORE).
+      # 正しいクラス名になるものだけ選ぶ
+      select { |botName| /\A[A-Z]/ === botName }
 
     validBotNames.map { |botName|
       require("#{diceBotDir}/#{botName}")

--- a/src/diceBot/DiceBotLoader.rb
+++ b/src/diceBot/DiceBotLoader.rb
@@ -2,6 +2,16 @@
 
 # ダイスボットの読み込みを担当するクラス
 class DiceBotLoader
+  # 収集時に無視するボット名
+  BOT_NAMES_TO_IGNORE = [
+    'DiceBot',
+    'DiceBotLoader',
+    'DiceBotLoaderList',
+    'baseBot',
+    '_Template',
+    'test'
+  ]
+
   # 登録されていないタイトルのダイスボットを読み込む
   # @param [String] gameTitle ゲームタイトル
   # @return [DiceBot] ダイスボットが存在した場合
@@ -22,6 +32,24 @@ class DiceBotLoader
       debug("DiceBot load ERROR!!!", e.to_s)
       nil
     end
+  end
+
+  # ダイスボットディレクトリに含まれるダイスボットを収集する
+  # @return [Array<DiceBot>]
+  def self.collectDiceBots
+    diceBotDir = File.expand_path(File.dirname(__FILE__))
+
+    require("#{diceBotDir}/DiceBot")
+
+    botFiles = Dir.glob("#{diceBotDir}/*.rb")
+    botNames =
+      botFiles.map { |botFile| File.basename(botFile, '.rb').untaint }
+    validBotNames = botNames - BOT_NAMES_TO_IGNORE
+
+    validBotNames.map { |botName|
+      require("#{diceBotDir}/#{botName}")
+      Object.const_get(botName).new
+    }
   end
 
   # 読み込み処理を初期化する


### PR DESCRIPTION
diceBotディレクトリ内の*.rbファイルを探してすべてのダイスボットを収集する処理をDiceBotLoaderに移しました。

この処理はexeファイル生成やどどんとふのDiceBotInfosで見られ、共通化が期待できます。また、diceBotディレクトリにあるDiceBotLoaderで `require_relative` と同様の読み込みを行うようにし、カレントディレクトリに影響されずに確実に読み込めるようにしました（どどんとふ側でBCDiceをサブモジュールにしようとしてディレクトリが変わった際に、特に効果的でした）。