### PR TITLE
Stringの破壊的メソッドを使わない

### DIFF
--- a/src/Rakefile
+++ b/src/Rakefile
@@ -7,7 +7,7 @@ task :default => :test
 namespace :test do
   desc 'ダイスボットのテストを行う'
   task :dicebots do
-    sh('ruby test.rb')
+    sh('RUBYOPT="--enable-frozen-string-literal" ruby test.rb')
   end
 
   Rake::TestTask.new(:dicebot_loaders) do |t|

--- a/src/Rakefile
+++ b/src/Rakefile
@@ -7,7 +7,11 @@ task :default => :test
 namespace :test do
   desc 'ダイスボットのテストを行う'
   task :dicebots do
-    sh('RUBYOPT="--enable-frozen-string-literal" ruby test.rb')
+    if RUBY_VERSION < '1.9'
+      sh('ruby test.rb')
+    else
+      sh('RUBYOPT="--enable-frozen-string-literal" ruby test.rb')
+    end
   end
 
   Rake::TestTask.new(:dicebot_loaders) do |t|

--- a/src/TableFileData.rb
+++ b/src/TableFileData.rb
@@ -280,7 +280,7 @@ class TableFileCreator
     
     gameType = @params['gameType'] if( gameType.nil? )
     gameType ||= ''
-    gameType.gsub!(':', '_')
+    gameType = gameType.gsub(':', '_')
     
     if( command.nil? )
       initCommand

--- a/src/bcdiceCore.rb
+++ b/src/bcdiceCore.rb
@@ -462,7 +462,7 @@ class BCDice
     end
     
     
-    arg << "->#{@tnick}" unless( @tnick.empty? )
+    arg += "->#{@tnick}" unless( @tnick.empty? )
     
     pointerMode = :sameNick
     output, pointerMode = countHolder.executeCommand(arg, @nick_e, channel, pointerMode)
@@ -737,7 +737,7 @@ class BCDice
     return if( output == "1" )
     
     if( @isTest )
-      output << "###secret dice###"
+      output += "###secret dice###"
     end
     
     broadmsg(output, @nick_e)

--- a/src/cgiDiceBot.rb
+++ b/src/cgiDiceBot.rb
@@ -50,16 +50,16 @@ class CgiDiceBot
     
     result = ""
     
-    result << "##>customBot BEGIN<##"
-    result << getDiceBotParamText('channel')
-    result << getDiceBotParamText('name')
-    result << getDiceBotParamText('state')
-    result << getDiceBotParamText('sendto')
-    result << getDiceBotParamText('color')
-    result << message
+    result += "##>customBot BEGIN<##"
+    result += getDiceBotParamText('channel')
+    result += getDiceBotParamText('name')
+    result += getDiceBotParamText('state')
+    result += getDiceBotParamText('sendto')
+    result += getDiceBotParamText('color')
+    result += message
     rollResult, randResults = roll(message, gameType)
-    result << rollResult
-    result << "##>customBot END<##"
+    result += rollResult
+    result += "##>customBot END<##"
     
     return result
   end
@@ -77,15 +77,15 @@ class CgiDiceBot
     result = ""
     
     unless( @isTest )
-      # result << "##>isSecretDice<##" if( @isSecret )
+      # result += "##>isSecretDice<##" if( @isSecret )
     end
     
     # 多言語対応のダイスボットは「GameType:Language」という書式なので、
     # ここで言語名を削って表示する。（内部的には必要だが、表示では不要のため）
-    gameType.gsub!(/:.+$/, '')
+    gameType = gameType.gsub(/:.+$/, '')
     
     unless( rollResult.empty? )
-      result << "\n#{gameType} #{rollResult}"
+      result += "\n#{gameType} #{rollResult}"
     end
     
     return result, randResults
@@ -149,16 +149,16 @@ class CgiDiceBot
   end
   
   def sendMessage(to, message)
-    @rollResult << message
+    @rollResult += message
   end
   
   def sendMessageToOnlySender(nick_e, message)
     @isSecret = true
-    @rollResult << message
+    @rollResult += message
   end
   
   def sendMessageToChannels(message)
-    @rollResult << message
+    @rollResult += message
   end
   
 end

--- a/src/diceBot/Airgetlamh.rb
+++ b/src/diceBot/Airgetlamh.rb
@@ -57,7 +57,7 @@ MESSAGETEXT
     resultDamage = diceCount * damage
 
     result = ""
-    result << "(#{rapid}D10\<\=#{target}) ＞ #{diceText} ＞ Success：#{diceCount}*#{damage} ＞ #{resultDamage}ダメージ"
+    result += "(#{rapid}D10\<\=#{target}) ＞ #{diceText} ＞ Success：#{diceCount}*#{damage} ＞ #{resultDamage}ダメージ"
     return result
   end
 end

--- a/src/diceBot/BarnaKronika.rb
+++ b/src/diceBot/BarnaKronika.rb
@@ -125,7 +125,7 @@ INFO_MESSAGE_TEXT
       next if(diceCount == 0)
 
       diceCount.times do |j|
-        output << "#{i + 1},"
+        output += "#{i + 1},"
       end
 
       if( isCriticalCall(i, criticalCallDice) )

--- a/src/diceBot/BattleTech.rb
+++ b/src/diceBot/BattleTech.rb
@@ -129,13 +129,13 @@ MESSAGETEXT
 
     count.times do
       isHit, hitResult = getHitText(base, target)
+      if isHit
+        hitCount += 1
+
+        damages, damageText = getDamages(damageFunc, partTable, damages)
+        hitResult += damageText
+      end
       resultTexts << hitResult
-
-      next unless( isHit )
-      hitCount += 1
-
-      damages, damageText = getDamages(damageFunc, partTable, damages)
-      resultTexts.last << damageText
     end
 
     totalResultText = resultTexts.join("\n")
@@ -144,8 +144,8 @@ MESSAGETEXT
       totalResultText = "..."
     end
 
-    totalResultText << "\n ＞ #{hitCount}回命中"
-    totalResultText << " 命中箇所：" + getTotalDamage(damages) if( hitCount > 0 )
+    totalResultText += "\n ＞ #{hitCount}回命中"
+    totalResultText += " 命中箇所：" + getTotalDamage(damages) if( hitCount > 0 )
 
     return totalResultText
   end
@@ -210,15 +210,15 @@ MESSAGETEXT
     damagePartCount = 1
     if( isLrm )
       damagePartCount = (1.0 * damage / @@lrmLimit).ceil
-      resultText << "[#{dice}] #{damage}点"
+      resultText += "[#{dice}] #{damage}点"
     end
 
     damagePartCount.times do |damageIndex|
       currentDamage, damageText = getDamageInfo(dice, damage, isLrm, damageIndex)
 
       text, part, criticalText = getHitResultOne(damageText, partTable)
-      resultText << " " if( isLrm )
-      resultText << text
+      resultText += " " if( isLrm )
+      resultText += text
 
       if( damages[part].nil? )
         damages[part] = {
@@ -268,8 +268,8 @@ MESSAGETEXT
       criticals = damageInfo[:criticals]
 
       text = ""
-      text << "#{part}(#{damageCount}回) #{damage}点"
-      text << " #{criticals.join(' ')}" unless( criticals.empty? )
+      text += "#{part}(#{damageCount}回) #{damage}点"
+      text += " #{criticals.join(' ')}" unless( criticals.empty? )
 
       damageTexts << text
     end
@@ -288,7 +288,7 @@ MESSAGETEXT
     part, value = getPart(partTable)
 
     result = ""
-    result << "[#{value}] #{part.gsub(/＠/, '（致命的命中）')} #{damageText}点"
+    result += "[#{value}] #{part.gsub(/＠/, '（致命的命中）')} #{damageText}点"
     debug('result', result)
 
     index = part.index('＠')
@@ -300,7 +300,7 @@ MESSAGETEXT
     criticalText = ''
     if( isCritical )
       criticalDice, criticalText = getCriticalResult()
-      result << " ＞ [#{criticalDice}] #{criticalText}"
+      result += " ＞ [#{criticalDice}] #{criticalText}"
     end
 
     criticalText = '' if( criticalText == @@noCritical )

--- a/src/diceBot/BeginningIdol.rb
+++ b/src/diceBot/BeginningIdol.rb
@@ -1391,7 +1391,7 @@ INFO_MESSAGE_TEXT
 
       numberString = ""
       nameParts.each do |index, src, text1, number1|
-        name.gsub!(src, text1)
+        name = name.gsub(src, text1)
         numberString += "#{src}#{number1},"
       end
       numberString = numberString[0, numberString.length - 1]
@@ -2264,8 +2264,8 @@ INFO_MESSAGE_TEXT
       text = "オフ"
       skill = ''
     else
-      text.slice!( matchedText)
-      text.slice!(/\n$/)
+      text = text.gsub(matchedText, '')
+      text = text.chomp
     end
 
     return text, skill
@@ -2413,7 +2413,7 @@ INFO_MESSAGE_TEXT
       text += 'と'
     end
 
-    text.slice!(/と$/)
+    text = text.sub(/と$/, '')
 
     return text
   end
@@ -2430,7 +2430,7 @@ INFO_MESSAGE_TEXT
     end
 
     substitution = text.clone
-    substitution.slice!($&)
+    substitution = substitution.gsub($&, '')
     substitution += "\n" unless substitution.empty? or /\n$/ =~ substitution
 
     return substitution + badStatus(counts)
@@ -2515,7 +2515,7 @@ INFO_MESSAGE_TEXT
     end
 
     text = textFromD66Table(title, table)
-    text.slice!(/\n.+$/) if brandOnly
+    text = text.split("\n").first if brandOnly
     return text
   end
 end

--- a/src/diceBot/BeginningIdol_Korean.rb
+++ b/src/diceBot/BeginningIdol_Korean.rb
@@ -1295,7 +1295,7 @@ INFO_MESSAGE_TEXT
 
       numberString = ""
       nameParts.each do |index, src, text1, number1|
-        name.gsub!(src, text1)
+        name = name.gsub(src, text1)
         numberString += "#{src}#{number1},"
       end
       numberString = numberString[0, numberString.length - 1]
@@ -2114,8 +2114,8 @@ INFO_MESSAGE_TEXT
       text = "오프"
       skill = ''
     else
-      text.slice!( matchedText)
-      text.slice!(/\n$/)
+      text = text.sub(matchedText, '')
+      text = text.chomp
     end
 
     return text, skill
@@ -2263,7 +2263,7 @@ INFO_MESSAGE_TEXT
       text += 'と'
     end
 
-    text.slice!(/と$/)
+    text = text.sub(/と$/, '')
 
     return text
   end
@@ -2280,7 +2280,7 @@ INFO_MESSAGE_TEXT
     end
 
     substitution = text.clone
-    substitution.slice!($&)
+    substitution = substitution.gsub($&, '')
     substitution += "\n" unless substitution.empty? or /\n$/ =~ substitution
 
     return substitution + badStatus(counts)
@@ -2365,7 +2365,7 @@ INFO_MESSAGE_TEXT
     end
 
     text = textFromD66Table(title, table)
-    text.slice!(/\n.+$/) if brandOnly
+    text = text.split("\n").first if brandOnly
     return text
   end
 end

--- a/src/diceBot/CodeLayerd.rb
+++ b/src/diceBot/CodeLayerd.rb
@@ -52,14 +52,14 @@ MESSAGETEXT
 
     target = 10 if target > 10
 
-    result << "(#{base}d10)"
+    result += "(#{base}d10)"
 
     _, diceText = roll(base, 10)
 
     diceList = diceText.split(/,/).collect{|i|i.to_i}.sort
 
-    result << " ＞ [#{diceList.join(',')}] ＞ "
-    result << getRollResultString(diceList, target, diff)
+    result += " ＞ [#{diceList.join(',')}] ＞ "
+    result += getRollResultString(diceList, target, diff)
 
     return result
   end
@@ -71,11 +71,11 @@ MESSAGETEXT
     successTotal = successCount + criticalCount
     result = ""
 
-    result << "判定値[#{target}] 達成値[#{successCount}]"
-    result << "+クリティカル[#{criticalCount}]=[#{successTotal}]" if criticalCount > 0
+    result += "判定値[#{target}] 達成値[#{successCount}]"
+    result += "+クリティカル[#{criticalCount}]=[#{successTotal}]" if criticalCount > 0
 
     successText = getSuccessResultText(successTotal, diff)
-    result << " ＞ #{successText}"
+    result += " ＞ #{successText}"
 
     return result
   end

--- a/src/diceBot/DiceBot.rb
+++ b/src/diceBot/DiceBot.rb
@@ -500,7 +500,7 @@ class DiceBot
         raise "invalid dice Type #{command}"
       end
 
-    text.gsub!("\\n", "\n")
+    text = text.gsub("\\n", "\n")
     text = @@bcdice.rollTableMessageDiceText(text)
     
     return nil if( text.nil? )

--- a/src/diceBot/EarthDawn.rb
+++ b/src/diceBot/EarthDawn.rb
@@ -98,34 +98,34 @@ INFO_MESSAGE_TEXT
       end
     end
 
-    string = ""
+    @string = ""
 
     debug('d20step, d12step, d10step, d8step, d6step, d4step', d20step, d12step, d10step, d8step, d6step, d4step)
 
-    stepTotal += rollStep(20, d20step, string)
-    stepTotal += rollStep(12, d12step, string)
-    stepTotal += rollStep(10, d10step, string)
-    stepTotal += rollStep( 8,  d8step, string)
-    stepTotal += rollStep( 6,  d6step, string)
-    stepTotal += rollStep( 4,  d4step, string)
+    stepTotal += rollStep(20, d20step)
+    stepTotal += rollStep(12, d12step)
+    stepTotal += rollStep(10, d10step)
+    stepTotal += rollStep( 8,  d8step)
+    stepTotal += rollStep( 6,  d6step)
+    stepTotal += rollStep( 4,  d4step)
 
     if( nmod > 0 )     #修正分の適用
-      string += "+"
+      @string += "+"
     end
 
     if( nmod != 0 )
-      string += "#{nmod}"
+      @string += "#{nmod}"
       stepTotal += nmod
     end
 
     #ステップ判定終了
-    string += " ＞ #{stepTotal}"
+    @string += " ＞ #{stepTotal}"
 
-    output = "ステップ#{step} ＞ #{string}"
+    output = "ステップ#{step} ＞ #{@string}"
     return output if(targetNumber == 0)
 
     #結果判定
-    string += ' ＞ '
+    @string += ' ＞ '
 
     excelentSuccessNumber  = stable[7][targetNumber - 1]
     superSuccessNumber   = stable[8][targetNumber - 1]
@@ -133,22 +133,22 @@ INFO_MESSAGE_TEXT
     failedNumber   = stable[11][targetNumber - 1]
 
     if( @isFailed )
-      string += '自動失敗'
+      @string += '自動失敗'
     elsif(stepTotal >= excelentSuccessNumber)
-      string += '最良成功'
+      @string += '最良成功'
     elsif(stepTotal >= superSuccessNumber)
-      string += '優成功'
+      @string += '優成功'
     elsif(stepTotal >= goodSuccessNumber)
-      string += '良成功'
+      @string += '良成功'
     elsif(stepTotal >= targetNumber)
-      string += '成功'
+      @string += '成功'
     elsif(stepTotal < failedNumber)
-      string += '大失敗'
+      @string += '大失敗'
     else
-      string += '失敗'
+      @string += '失敗'
     end
 
-    output = "ステップ#{step}>=#{targetNumber} ＞ #{string}"
+    output = "ステップ#{step}>=#{targetNumber} ＞ #{@string}"
 
     return output
   end
@@ -186,17 +186,17 @@ INFO_MESSAGE_TEXT
   # + [(xx-45)/11]d20
   # + ステップ[(xx-34)を11で割った余り+3]のダイス
 
-  def rollStep(diceType, diceCount, string)
-    debug('rollStep diceType, diceCount, string', diceType, diceCount, string)
+  def rollStep(diceType, diceCount)
+    debug('rollStep diceType, diceCount, @string', diceType, diceCount, @string)
 
     stepTotal = 0
     return stepTotal unless(diceCount > 0)
 
     #diceぶんのステップ判定
 
-    string << "+" unless(string.empty? )
-    string << "#{diceCount}d#{diceType}["
-    debug('rollStep string', string)
+    @string += "+" unless(@string.empty? )
+    @string += "#{diceCount}d#{diceType}["
+    debug('rollStep @string', @string)
 
     diceCount.times do |i|
       dice_now, dummy = roll(1, diceType)
@@ -215,11 +215,11 @@ INFO_MESSAGE_TEXT
 
       stepTotal += dice_in
 
-      string << ',' if( i != 0 )
-      string << "#{dice_in}"
+      @string += ',' if( i != 0 )
+      @string += "#{dice_in}"
     end
 
-    string << "]"
+    @string += "]"
 
     return stepTotal
   end

--- a/src/diceBot/EarthDawn3.rb
+++ b/src/diceBot/EarthDawn3.rb
@@ -66,42 +66,42 @@ INFO_MESSAGE_TEXT
     stepInfo = getStepInfo(step)
     debug('stepInfo', stepInfo)
 
-    string = ""
+    @string = ""
 
     diceTypes = [20, 12, 10, 8, 6, 4]
     diceTypes.each do |type|
-      stepTotal += rollStep(type, stepInfo.shift, string)
+      stepTotal += rollStep(type, stepInfo.shift)
     end
     modify = stepInfo.shift
 
     karmaDiceInfo.each do |diceType, diceCount|
-      stepTotal += rollStep(diceType, diceCount, string)
+      stepTotal += rollStep(diceType, diceCount)
     end
 
-    string += (getModifyText(modify) + getModifyText(diceModify))
+    @string += (getModifyText(modify) + getModifyText(diceModify))
     stepTotal += (modify + diceModify)
 
     #ステップ判定終了
-    string += " ＞ #{stepTotal}"
+    @string += " ＞ #{stepTotal}"
 
-    output = "ステップ#{step} ＞ #{string}"
+    output = "ステップ#{step} ＞ #{@string}"
     return output if(targetNumber == 0)
 
     #結果判定
-    string += ' ＞ ' + getSuccess(targetNumber, stepTotal)
+    @string += ' ＞ ' + getSuccess(targetNumber, stepTotal)
 
-    output = "ステップ#{step}>=#{targetNumber} ＞ #{string}"
+    output = "ステップ#{step}>=#{targetNumber} ＞ #{@string}"
 
     return output
   end
 
   def getModifyText(modify)
-    string = ""
-    return string if( modify == 0 )
+    @string = ""
+    return @string if( modify == 0 )
 
-    string += "+" if( modify > 0 )
-    string += "#{modify}"
-    return string
+    @string += "+" if( modify > 0 )
+    @string += "#{modify}"
+    return @string
   end
 
   def getBaseStepTable
@@ -237,17 +237,17 @@ INFO_MESSAGE_TEXT
     return successTable
   end
 
-  def rollStep(diceType, diceCount, string)
-    debug('rollStep diceType, diceCount, string', diceType, diceCount, string)
+  def rollStep(diceType, diceCount)
+    debug('rollStep diceType, diceCount, @string', diceType, diceCount, @string)
 
     stepTotal = 0
     return stepTotal unless(diceCount > 0)
 
     #diceぶんのステップ判定
 
-    string << "+" unless(string.empty? )
-    string << "#{diceCount}d#{diceType}["
-    debug('rollStep string', string)
+    @string += "+" unless(@string.empty? )
+    @string += "#{diceCount}d#{diceType}["
+    debug('rollStep @string', @string)
 
     diceCount.times do |i|
       dice_now, dummy = roll(1, diceType)
@@ -266,11 +266,11 @@ INFO_MESSAGE_TEXT
 
       stepTotal += dice_in
 
-      string << ',' if( i != 0 )
-      string << "#{dice_in}"
+      @string += ',' if( i != 0 )
+      @string += "#{dice_in}"
     end
 
-    string << "]"
+    @string += "]"
 
     return stepTotal
   end

--- a/src/diceBot/EarthDawn4.rb
+++ b/src/diceBot/EarthDawn4.rb
@@ -9,6 +9,7 @@ class EarthDawn4 < EarthDawn
     super
     @sendMode = 2
     @sortType = 1
+    @calcText = ''
   end
 
   def gameName
@@ -36,7 +37,6 @@ INFO_MESSAGE_TEXT
 
   #アースドーンステップ表
   def ed_step(str)
-
     output = getStepResult(str)
 
     return output
@@ -114,22 +114,22 @@ INFO_MESSAGE_TEXT
     stepInfo = getStepInfo(step)
     debug('stepInfo', stepInfo)
 
-    calcText = ""
+    @calcText = ""
 
     diceTypes = [20, 12, 10, 8, 6, 4]
     diceTypes.each do |type|
-      stepTotal += rollStep(type, stepInfo.shift, calcText)
+      stepTotal += rollStep(type, stepInfo.shift)
     end
     modify = stepInfo.shift
 
-    stepTotal += rollStep(6, 1, calcText) if( hasKarmaDice )
+    stepTotal += rollStep(6, 1) if( hasKarmaDice )
 
-    calcText += (getModifyText(modify) + getModifyText(diceModify))
+    @calcText += (getModifyText(modify) + getModifyText(diceModify))
     stepTotal += (modify + diceModify)
 
     stepText = "ステップ#{step}"
 
-    return stepText, calcText, stepTotal, targetNumber, nextText
+    return stepText, @calcText, stepTotal, targetNumber, nextText
   end
 
   def getModifyText(modify)
@@ -232,17 +232,17 @@ INFO_MESSAGE_TEXT
     return "成功 レベル：#{level}"
   end
 
-  def rollStep(diceType, diceCount, string)
-    debug('rollStep diceType, diceCount, string', diceType, diceCount, string)
+  def rollStep(diceType, diceCount)
+    debug('rollStep diceType, diceCount, @calcText', diceType, diceCount, @calcText)
 
     stepTotal = 0
     return stepTotal unless(diceCount > 0)
 
     #diceぶんのステップ判定
 
-    string << "+" unless(string.empty? )
-    string << "#{diceCount}d#{diceType}["
-    debug('rollStep string', string)
+    @calcText += "+" unless(@calcText.empty?)
+    @calcText += "#{diceCount}d#{diceType}["
+    debug('rollStep string', @calcText)
 
     diceCount.times do |i|
       dice_now, dummy = roll(1, diceType)
@@ -261,11 +261,11 @@ INFO_MESSAGE_TEXT
 
       stepTotal += dice_in
 
-      string << ',' if( i != 0 )
-      string << "#{dice_in}"
+      @calcText += ',' if( i != 0 )
+      @calcText += "#{dice_in}"
     end
 
-    string << "]"
+    @calcText += "]"
 
     return stepTotal
   end

--- a/src/diceBot/Elysion.rb
+++ b/src/diceBot/Elysion.rb
@@ -162,15 +162,15 @@ MESSAGETEXT
     total = diceTotal + addTotal
 
     result = ""
-    result << "(2D6#{getValueString(base)}#{getValueString(modify)})"
-    result << " ＞ #{diceTotal}[#{dice1},#{dice2}]#{getValueString(addTotal)} ＞ #{total}"
+    result += "(2D6#{getValueString(base)}#{getValueString(modify)})"
+    result += " ＞ #{diceTotal}[#{dice1},#{dice2}]#{getValueString(addTotal)} ＞ #{total}"
 
     if dice1 == dice2
-      result << getSpecialResult(dice1, total)
+      result += getSpecialResult(dice1, total)
       return result
     end
 
-    result << getCheckResult(total)
+    result += getCheckResult(total)
 
     return result
   end
@@ -196,7 +196,7 @@ MESSAGETEXT
   def getSuccessResult(success)
 
     result = " ＞ 成功度#{success}"
-    result << " ＞ 大成功 《アウル》2点獲得" if success >= @@successMax
+    result += " ＞ 大成功 《アウル》2点獲得" if success >= @@successMax
 
     return result
   end
@@ -232,7 +232,7 @@ MESSAGETEXT
     end
 
     result = getCheckResult(total)
-    result << " ／ (#{number - 1}回目のアシストなら)大失敗"
+    result += " ／ (#{number - 1}回目のアシストなら)大失敗"
 
     debug("getFambleResultText result", result)
 
@@ -254,7 +254,7 @@ MESSAGETEXT
       number = dice2 * 10 + dice1
     end
 
-    result <<  getDateResult(type, number, pc1, pc2)
+    result +=  getDateResult(type, number, pc1, pc2)
 
     return result
   end

--- a/src/diceBot/Garako.rb
+++ b/src/diceBot/Garako.rb
@@ -111,8 +111,8 @@ MESSAGETEXT
     text = getResultText(dice, total, target)
 
     result = ""
-    result << "(1D10#{modifyString}>#{total})"
-    result << " ＞ #{total}[#{dice}#{modifyString}] ＞ #{total} ＞ #{text}"
+    result += "(1D10#{modifyString}>#{total})"
+    result += " ＞ #{total}[#{dice}#{modifyString}] ＞ #{total} ＞ #{text}"
 
     return result
   end

--- a/src/diceBot/GoldenSkyStories.rb
+++ b/src/diceBot/GoldenSkyStories.rb
@@ -52,7 +52,7 @@ MESSAGETEXT
     diceList = diceText.split(/,/).collect{|i|i.to_i}
 
     #result << " あーしたてんきになーれっ ＞ [#{diceList.join(',')}] ＞ "
-    result << "下駄占い ＞ "
+    result += "下駄占い ＞ "
 
     getaString = ''
     case(diceList[0])
@@ -72,7 +72,7 @@ MESSAGETEXT
         getaString = '横：くもり'
     end
 
-    result << getaString
+    result += getaString
 
     return result
   end

--- a/src/diceBot/HarnMaster.rb
+++ b/src/diceBot/HarnMaster.rb
@@ -112,7 +112,7 @@ MESSAGETEXT
 
     side = (((number % 2) == 1) ? "左" : "右")
 
-    part.sub!(/\*/, side)
+    part.sub(/\*/, side)
   end
 
   def getFaceLocation(part)

--- a/src/diceBot/Kamigakari.rb
+++ b/src/diceBot/Kamigakari.rb
@@ -175,7 +175,7 @@ INFO_MESSAGE_TEXT
     if( /\+n/ === result )
       power, number2 = getMaterialEffectPower(rank)
 
-      result.sub!(/\+n/, "+#{power}")
+      result = result.sub(/\+n/, "+#{power}")
       number = "#{number},#{number2}"
     end
 
@@ -208,7 +208,7 @@ INFO_MESSAGE_TEXT
 
     if( /\*\*/ === result )
       attribute, number2 = getAttribute()
-      result.sub!(/\*\*/, "#{attribute}")
+      result = result.sub(/\*\*/, "#{attribute}")
       number = "#{number},#{number2}"
     end
 

--- a/src/diceBot/Kamigakari_Korean.rb
+++ b/src/diceBot/Kamigakari_Korean.rb
@@ -342,7 +342,7 @@ INFO_MESSAGE_TEXT
     if( /\+n/ === result )
       power, number2 = getMaterialEffectPower(rank)
 
-      result.sub!(/\+n/, "+#{power}")
+      result = result.sub(/\+n/, "+#{power}")
       number = "#{number},#{number2}"
     end
 
@@ -375,7 +375,7 @@ INFO_MESSAGE_TEXT
 
     if( /\*\*/ === result )
       attribute, number2 = getAttribute()
-      result.sub!(/\*\*/, "#{attribute}")
+      result = result.sub(/\*\*/, "#{attribute}")
       number = "#{number},#{number2}"
     end
 

--- a/src/diceBot/MeikyuKingdom.rb
+++ b/src/diceBot/MeikyuKingdom.rb
@@ -80,7 +80,7 @@ INFO_MESSAGE_TEXT
 
   def check_2D6(total_n, dice_n, signOfInequality, diff, dice_cnt, dice_max, n1, n_max)  # ゲーム別成功度判定(2D6)
     result = get2D6Result(total_n, dice_n, signOfInequality, diff)
-    result << getKiryokuResult(total_n, dice_n, signOfInequality, diff)
+    result += getKiryokuResult(total_n, dice_n, signOfInequality, diff)
 
     return result
   end

--- a/src/diceBot/Paranoia.rb
+++ b/src/diceBot/Paranoia.rb
@@ -48,7 +48,7 @@ MESSAGETEXT
 
     diceList = diceText.split(/,/).collect{|i|i.to_i}
 
-    result << "幸福ですか？ ＞ "
+    result += "幸福ですか？ ＞ "
 
     getaString = ''
     case(diceList[0])
@@ -58,7 +58,7 @@ MESSAGETEXT
         getaString = '幸福ではありません'
     end
 
-    result << getaString
+    result += getaString
 
     return result
   end

--- a/src/diceBot/ShinMegamiTenseiKakuseihen.rb
+++ b/src/diceBot/ShinMegamiTenseiKakuseihen.rb
@@ -38,11 +38,11 @@ INFO_MESSAGE_TEXT
     isRepdigit = ( dice1 == dice2 )
     
     result = " ＞ スワップ"
-    result << getCheckResultText(diff, [total1, total2].min, isRepdigit)
-    result << "／通常"
-    result << getCheckResultText(diff, total_n, isRepdigit)
-    result << "／逆スワップ"
-    result << getCheckResultText(diff, [total1, total2].max, isRepdigit)
+    result += getCheckResultText(diff, [total1, total2].min, isRepdigit)
+    result += "／通常"
+    result += getCheckResultText(diff, total_n, isRepdigit)
+    result += "／逆スワップ"
+    result += getCheckResultText(diff, [total1, total2].max, isRepdigit)
     
     return result
   end

--- a/src/diceBot/Utakaze.rb
+++ b/src/diceBot/Utakaze.rb
@@ -62,14 +62,14 @@ MESSAGETEXT
 
     crit = 6 if( crit > 6 )
 
-    result << "(#{base}d6)"
+    result += "(#{base}d6)"
 
     _, diceText = roll(base, 6)
 
     diceList = diceText.split(/,/).collect{|i|i.to_i}.sort
 
-    result << " ＞ [#{diceList.join(',')}] ＞ "
-    result << getRollResultString(diceList, crit, diff)
+    result += " ＞ [#{diceList.join(',')}] ＞ "
+    result += getRollResultString(diceList, crit, diff)
 
     return result
   end
@@ -81,22 +81,22 @@ MESSAGETEXT
     result = ""
 
     if( isDragonDice(crit) )
-      result << "龍のダイス「#{@arrayDragonDiceName[crit]}」(#{crit.to_s})を使用 ＞ "
+      result += "龍のダイス「#{@arrayDragonDiceName[crit]}」(#{crit.to_s})を使用 ＞ "
     end
 
     if( success )
-      result << "成功レベル:#{maxnum} (#{setCount}セット)"
+      result += "成功レベル:#{maxnum} (#{setCount}セット)"
       if( diff != 0 )
         diffSuccess = (maxnum >= diff)
         if( diffSuccess )
-          result << " ＞ 成功"
+          result += " ＞ 成功"
         else
-          result << " ＞ 失敗"
+          result += " ＞ 失敗"
         end
       end
 
     else
-      result << "失敗"
+      result += "失敗"
     end
 
     return result

--- a/src/diceBot/ZettaiReido.rb
+++ b/src/diceBot/ZettaiReido.rb
@@ -44,17 +44,17 @@ INFO_MESSAGE_TEXT
     diff, diffText = getDiffInfo(diffValue)
 
     output = ""
-    output << "(#{baseAvility}-2DR#{modText}#{diffText})"
-    output << " ＞ #{baseAvility}-#{diceTotal}[#{diceText}]#{modText}"
+    output += "(#{baseAvility}-2DR#{modText}#{diffText})"
+    output += " ＞ #{baseAvility}-#{diceTotal}[#{diceText}]#{modText}"
 
     total = baseAvility - diceTotal + mod
-    output << " ＞ #{total}"
+    output += " ＞ #{total}"
 
     successText = getSuccessText(diceTotal, total, diff)
-    output << successText
+    output += successText
 
     darkPointText = getDarkPointResult(total, diff, darkPoint)
-    output << darkPointText
+    output += darkPointText
 
     return output
   end

--- a/src/test/DiceBotTest.rb
+++ b/src/test/DiceBotTest.rb
@@ -142,12 +142,12 @@ class DiceBotTest
 
     result = ''
     testData.input.each do |message|
-      result << @bot.roll(message, testData.gameType, @tableDir).first
+      result += @bot.roll(message, testData.gameType, @tableDir).first
     end
 
     unless rands.empty?
-      result << "\nダイス残り："
-      result << rands.map { |r| r.join('/') }.join(', ')
+      result += "\nダイス残り："
+      result += rands.map { |r| r.join('/') }.join(', ')
     end
 
     result


### PR DESCRIPTION
## 何をしたか

コード中でStringの破壊的メソッドを使わないようにした

## なぜしたか

- OpalがStringの破壊的メソッドをサポートしていないため (bcdice-js向け)
- Ruby 3系ではStringはimmutableになり、破壊的メソッドは利用不可になるため

## Before

結果の文字列生成などに、`String#<<` のような破壊的メソッドが使われていた。

```ruby
result = ""
result << "#{getFoo} ＞ #{getBar}"
```

```ruby
gameType.gsub!(':', '_')
```

## After

`String#+=` などの非破壊的メソッドを使うようにした。

```ruby
result = ""
result += "#{getFoo} ＞ #{getBar}"
```

```ruby
gameType = gameType.gsub(':', '_')
```

テスト実行時にstringがimmutableであることを強制するようにした。

```ruby
sh('RUBYOPT="--enable-frozen-string-literal" ruby test.rb')
```
